### PR TITLE
Feature/reporting metrics to statsd

### DIFF
--- a/api/metrics_reporter.go
+++ b/api/metrics_reporter.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/topfreegames/extensions/dogstatsd"
+)
+
+// MetricTypes constants
+var MetricTypes = struct {
+	APIRequestPath string
+}{
+	APIRequestPath: "api_request_path",
+}
+
+// MetricsReporter interface
+type MetricsReporter interface {
+	Timing(metric string, value time.Duration, tags ...string) error
+	Gauge(metrics string, value float64, tags ...string) error
+	Increment(metric string, tags ...string) error
+}
+
+// NewMetricsReporter ctor
+func NewMetricsReporter(config *viper.Viper) (MetricsReporter, error) {
+	return NewDogStatsD(config)
+}
+
+// DogStatsD metrics reporter struct
+type DogStatsD struct {
+	client     dogstatsd.Client
+	rate       float64
+	tagsPrefix string
+}
+
+func loadDefaultConfigsDogStatsD(config *viper.Viper) {
+	config.SetDefault("dogstatsd.host", "localhost:8125")
+	config.SetDefault("dogstatsd.prefix", "arkadiko.")
+	config.SetDefault("dogstatsd.tags_prefix", "arkadiko.")
+	config.SetDefault("dogstatsd.rate", "1")
+}
+
+// NewDogStatsD ctor
+func NewDogStatsD(config *viper.Viper) (*DogStatsD, error) {
+	loadDefaultConfigsDogStatsD(config)
+	host := config.GetString("dogstatsd.host")
+	prefix := config.GetString("dogstatsd.prefix")
+	tagsPrefix := config.GetString("dogstatsd.tags_prefix")
+	rate, err := strconv.ParseFloat(config.GetString("dogstatsd.rate"), 64)
+	if err != nil {
+		return nil, err
+	}
+	c, err := dogstatsd.New(host, prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &DogStatsD{
+		client:     c,
+		rate:       rate,
+		tagsPrefix: tagsPrefix,
+	}, nil
+}
+
+func prefixTags(prefix string, tags ...string) {
+	for i, t := range tags {
+		tags[i] = fmt.Sprintf("%s%s", prefix, t)
+	}
+}
+
+// Timing reports time interval taken for something
+func (d *DogStatsD) Timing(
+	metric string, value time.Duration, tags ...string,
+) error {
+	prefixTags(d.tagsPrefix, tags...)
+	return d.client.Timing(metric, value, tags, d.rate)
+}
+
+// Gauge reports a numeric value that can go up or down
+func (d *DogStatsD) Gauge(
+	metric string, value float64, tags ...string,
+) error {
+	prefixTags(d.tagsPrefix, tags...)
+	return d.client.Gauge(metric, value, tags, d.rate)
+}
+
+// Increment reports an increment to some metric
+func (d *DogStatsD) Increment(metric string, tags ...string) error {
+	prefixTags(d.tagsPrefix, tags...)
+	return d.client.Incr(metric, tags, d.rate)
+}

--- a/config/local.yml
+++ b/config/local.yml
@@ -19,3 +19,8 @@ sentry:
 jaeger:
   disabled: true
   samplingProbability: 0.001
+dogstatsd:
+  host: localhost:8125
+  prefix: arkadiko.
+  tags_prefix: ""
+  rate: 1

--- a/config/test.yml
+++ b/config/test.yml
@@ -17,3 +17,4 @@ dogstatsd:
   prefix: arkadiko.
   tags_prefix: ""
   rate: 1
+

--- a/config/test.yml
+++ b/config/test.yml
@@ -12,3 +12,8 @@ redis:
 jaeger:
   disabled: false
   samplingProbability: 1.0
+dogstatsd:
+  host: localhost:8125
+  prefix: arkadiko.
+  tags_prefix: ""
+  rate: 1


### PR DESCRIPTION
This PR integrates arkadiko with DatadogStatsD and starts collecting the following metrics:

* latency (avg, percentile 50 and percentile95) [metric arkadiko.response_time_milliseconds]
* requests (per route and per status code) [metric arkadiko.response_time_milliseconds_count]

Due to a version incompatibility regarding echo, it was not possible to import `github.com/topfreegames/extensions/echo/middleware`. Therefore, this PR contains duplicate code from `github.com/topfreegames/extensions/echo/middleware`.

Also, it's important to notice arkadiko now expects a config section `dogstatsd.*`, where `*` is equal to `host, prefix, tags_prefix or rate`, instead of `extensions.dogstatsd.*`. It's common to find this last pattern in projects using `topfreegames/extensions`.