### PR TITLE
fix: downgrade MQTT QoS from 2 to 1

### DIFF
--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -105,7 +105,7 @@ func (mc *HttpClient) SendMessage(ctx context.Context, topic string, payload str
 		Topic:    topic,
 		Payload:  payload,
 		Retain:   retainBool,
-		Qos:      2,
+		Qos:      1,
 		ClientId: fmt.Sprintf("arkadiko-%s", uuid.NewV4().String()),
 	}
 

--- a/mqttclient/mqttclient.go
+++ b/mqttclient/mqttclient.go
@@ -106,7 +106,7 @@ func (mc *MqttClient) PublishMessage(ctx context.Context, topic string, message 
 	l.Debug("Publishing message to mqtt")
 
 	for i := 0; i < 3; i++ { // Retry up to 3 times
-		token := mc.MqttClient.WithContext(ctx).Publish(topic, 2, retained, message)
+		token := mc.MqttClient.WithContext(ctx).Publish(topic, 1, retained, message)
 		if token.WaitTimeout(mc.Timeout) {
 			l.Debug("message published to mqtt")
 			break


### PR DESCRIPTION
## Summary
- Downgrade MQTT publish QoS from 2 (exactly-once) to 1 (at-least-once) in both `mqttclient` and `httpclient`
- Fixes `receive_maximum_exceeded` dropped messages and disconnection spikes on EMQX v5.8.4
- Related: emqx/emqx#13399 (broker returns wrong Receive Maximum in CONNACK)

## Root Cause
On Mar 28, 2026 ~21:00 UTC, arkadiko experienced a spike in disconnections and dropped QoS 2 packets. The EMQX broker's `max_awaiting_rel=100` limit was overwhelmed during a traffic burst. QoS 2 requires a 4-step handshake (`PUBLISH → PUBREC → PUBREL → PUBCOMP`), and each in-flight message stays in "awaiting PUBREL" state. With no client-side flow control and an EMQX bug (#13399) preventing correct Receive Maximum advertisement, the broker dropped packets exceeding the limit.

QoS 1 uses a simple 2-step handshake (`PUBLISH → PUBACK`) with no awaiting_rel state, completely eliminating this bottleneck.

## Test plan
- [x] `go test ./...` — all relevant tests pass (pre-existing failures unrelated to this change)
- [ ] After deploy, verify `arkadiko_mqtt_disconnections` metric stays flat
- [ ] Confirm no `dropped_qos2_packet` warnings in EMQX logs
- [ ] Verify `awaiting_rel=0` on arkadiko client connections via `emqx_ctl clients list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MQTT delivery semantics from exactly-once to at-least-once, which can introduce duplicate message delivery for consumers. While small, it affects core messaging behavior across both MQTT and HTTP publish paths.
> 
> **Overview**
> Downgrades MQTT publish QoS from `2` to `1` across both publishing paths: the HTTP-based publisher (`httpclient.SendMessage` via `/api/v4/mqtt/publish`) and the direct MQTT publisher (`mqttclient.PublishMessage`).
> 
> This reduces the protocol handshake/in-flight state required for publishes, aiming to avoid broker-side dropped QoS2 packets and disconnect spikes under load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c22a1d89e829c5cf6eadd2142a2aa2adfa3e1910. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->